### PR TITLE
Fix issue#12

### DIFF
--- a/MAS/compose.yml
+++ b/MAS/compose.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis
+    ports:
+      - 6379:6379

--- a/MAS/docker-compose.yml
+++ b/MAS/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   redis:
     image: redis

--- a/MAS/docker-compose.yml
+++ b/MAS/docker-compose.yml
@@ -1,5 +1,0 @@
-services:
-  redis:
-    image: redis
-    ports:
-      - 6379:6379


### PR DESCRIPTION
DockerComposeのバージョンが上がったことによるWARNへの対応

- versionが非推奨になった
- docker-compose.ymlは後方互換性のために読み込むが、ベースとなるのはcompose.ymlに変更されている

以上のCompose v2に対する対応として、以下を実施した

- docker-compose.yml内のversionを削除
- docker-compose.ymlを複製してcompose.ymlを作成
- docker-compose.ymlを削除