### PR TITLE
Fix issue #4

### DIFF
--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -48,14 +48,12 @@ class Window:
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
         if folder_path == '':
             return
-        if not os.path.exists(WORK_FOLDER_PATH):
-            shutil.move(folder_path, WORK_FOLDER_PATH)
-            return
         if os.path.isfile(WORK_FOLDER_PATH):
             os.remove(WORK_FOLDER_PATH)
             shutil.move(folder_path, WORK_FOLDER_PATH)
             return
-        shutil.rmtree(WORK_FOLDER_PATH)
+        if os.path.exists(WORK_FOLDER_PATH):
+            shutil.rmtree(WORK_FOLDER_PATH)
         shutil.move(folder_path, WORK_FOLDER_PATH)
         
     def folder_export(self):

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -1,5 +1,6 @@
 import tkinter
 from tkinter import filedialog
+import tkinter.messagebox as messagebox
 import subprocess
 import os
 import shutil
@@ -37,7 +38,8 @@ class Window:
         self.root.mainloop()
         
     def vscode_open(self):
-        subprocess.Popen(['code', '-n', WORK_FOLDER_PATH])
+        if os.path.isdir(WORK_FOLDER_PATH):
+            subprocess.Popen(['code', '-n', WORK_FOLDER_PATH])
         
     def folder_change(self):
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -40,6 +40,9 @@ class Window:
     def vscode_open(self):
         if os.path.isdir(WORK_FOLDER_PATH):
             subprocess.Popen(['code', '-n', WORK_FOLDER_PATH])
+        else:
+            tkinter.Tk().withdraw()
+            messagebox.showinfo("ERROR","workフォルダがありません\n「work差替」からworkフォルダを設定してください")
         
     def folder_change(self):
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -22,7 +22,7 @@ class Window:
         self.label_folder.pack(anchor=tkinter.NW)
         self.button_open = tkinter.Button(self.frame_folder, text='VSCodeで開く', font=('MSゴシック', '20'), padx=2, pady=2, relief=tkinter.RAISED, width=19, height=2, background='white', command=self.vscode_open)
         self.button_open.pack(anchor=tkinter.W, pady=5)
-        self.button_change = tkinter.Button(self.frame_folder, text='work差替', font=('MSゴシック', '20'), padx=2, pady=2, width=8, background='white', command=self.folder_change)
+        self.button_change = tkinter.Button(self.frame_folder, text='work差替', font=('MSゴシック', '20'), padx=2, pady=2, width=8, background='white', command=self.workDir_change)
         self.button_change.pack(side=tkinter.LEFT)
         self.button_export = tkinter.Button(self.frame_folder, text='zipで出力', font=('MSゴシック', '20'), padx=2, pady=2, width=8, background='white', command=self.folder_export)
         self.button_export.pack(side=tkinter.LEFT)
@@ -43,7 +43,7 @@ class Window:
             tkinter.Tk().withdraw()
             messagebox.showinfo("ERROR","workフォルダがありません\n「work差替」からworkフォルダを設定してください")
         
-    def folder_change(self):
+    def workDir_change(self):
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
         if folder_path == '':
             return

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -36,7 +36,7 @@ class Window:
         self.button_run.pack(anchor=tkinter.W, pady=5)
         
         self.root.mainloop()
-        
+    
     def vscode_open(self):
         if os.path.isdir(WORK_FOLDER_PATH):
             subprocess.Popen(['code', '-n', WORK_FOLDER_PATH])
@@ -47,6 +47,9 @@ class Window:
     def folder_change(self):
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
         if folder_path == '':
+            return
+        if not os.path.exists(WORK_FOLDER_PATH):
+            shutil.move(folder_path, WORK_FOLDER_PATH)
             return
         if os.path.isfile(WORK_FOLDER_PATH):
             os.remove(WORK_FOLDER_PATH)

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -48,10 +48,6 @@ class Window:
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
         if folder_path == '':
             return
-        if os.path.isfile(WORK_FOLDER_PATH):
-            os.remove(WORK_FOLDER_PATH)
-            shutil.move(folder_path, WORK_FOLDER_PATH)
-            return
         if os.path.exists(WORK_FOLDER_PATH):
             shutil.rmtree(WORK_FOLDER_PATH)
         shutil.move(folder_path, WORK_FOLDER_PATH)

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -48,7 +48,10 @@ class Window:
         if work_path == '':
             return
         if os.path.exists(WORK_FOLDER_PATH):
-            shutil.rmtree(WORK_FOLDER_PATH)
+            if os.path.isdir(WORK_FOLDER_PATH):
+                shutil.rmtree(WORK_FOLDER_PATH)
+            else:
+                os.remove(WORK_FOLDER_PATH)
         shutil.move(work_path, WORK_FOLDER_PATH)
         
     def folder_export(self):

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -44,12 +44,12 @@ class Window:
             messagebox.showinfo("ERROR","workフォルダがありません\n「work差替」からworkフォルダを設定してください")
         
     def workDir_change(self):
-        folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
-        if folder_path == '':
+        work_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
+        if work_path == '':
             return
         if os.path.exists(WORK_FOLDER_PATH):
             shutil.rmtree(WORK_FOLDER_PATH)
-        shutil.move(folder_path, WORK_FOLDER_PATH)
+        shutil.move(work_path, WORK_FOLDER_PATH)
         
     def folder_export(self):
         shutil.make_archive('archive_work', format='zip', root_dir=WORK_FOLDER_PATH[:-len('/work')], base_dir='work')

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -1,6 +1,5 @@
 import tkinter
-from tkinter import filedialog
-import tkinter.messagebox as messagebox
+from tkinter import filedialog, messagebox
 import subprocess
 import os
 import shutil

--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -48,6 +48,10 @@ class Window:
         folder_path = filedialog.askdirectory(initialdir=USER_DESKTOP_PATH)
         if folder_path == '':
             return
+        if os.path.isfile(WORK_FOLDER_PATH):
+            os.remove(WORK_FOLDER_PATH)
+            shutil.move(folder_path, WORK_FOLDER_PATH)
+            return
         shutil.rmtree(WORK_FOLDER_PATH)
         shutil.move(folder_path, WORK_FOLDER_PATH)
         


### PR DESCRIPTION
Fix issue #4 空のworkが生成されて面倒

## 変更点

- VSCodeでworkフォルダを開く関数（vscode_open）
  - フォルダの存在チェックプロセスを追加
  - workフォルダが存在しなかった場合に、フォルダがないという旨のダイアログメッセージを出す
- 指定したフォルダをworkとして取り込む関数（folder_change -> workDir_change）
  - 既存workフォルダのパスが有効でない（フォルダ・ファイルが存在しない）時に移動するだけにする
  - 既存workフォルダのパスが有効な（フォルダ・ファイルが存在する）時は、削除する
    - フォルダの場合とファイルの場合で使用する方法が異なるので分岐