### PR TITLE
Fix issue#5

### DIFF
--- a/MAS/MAS.py
+++ b/MAS/MAS.py
@@ -3,6 +3,7 @@ from tkinter import filedialog, messagebox
 import subprocess
 import os
 import shutil
+import send2trash as trash
 
 WORK_FOLDER_PATH = os.path.dirname(__file__)+'/MAS/work'
 USER_DESKTOP_PATH = os.path.expanduser('~')+'/Desktop'
@@ -48,10 +49,7 @@ class Window:
         if work_path == '':
             return
         if os.path.exists(WORK_FOLDER_PATH):
-            if os.path.isdir(WORK_FOLDER_PATH):
-                shutil.rmtree(WORK_FOLDER_PATH)
-            else:
-                os.remove(WORK_FOLDER_PATH)
+            trash.send2trash(WORK_FOLDER_PATH)
         shutil.move(work_path, WORK_FOLDER_PATH)
         
     def folder_export(self):

--- a/MAS/requirements.txt
+++ b/MAS/requirements.txt
@@ -2,3 +2,4 @@ experta>=1.9.4
 paho-mqtt>=1.6.1
 redis>=5.0.1
 schema>=0.6.7
+send2trash>=1.8.0


### PR DESCRIPTION
Fix issue #5 workで指定をミスるとフォルダが消滅して復元できない

## 変更

- send2trashライブラリの導入（setupで入れるものに追加する）
- 削除ではなくゴミ箱へ元のworkを移動する